### PR TITLE
Java7 / JDK7 compiler compatibility for LogBlock

### DIFF
--- a/src/de/diddiz/util/MySQLConnectionPool.java
+++ b/src/de/diddiz/util/MySQLConnectionPool.java
@@ -21,6 +21,7 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Vector;
+import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 


### PR DESCRIPTION
These commits add the unimplemented methods that Java7 requires so that LogBlock compiles successfully under a JDK7 javac
