### PR TITLE
Added option to disallow tool dropping to prevent item duplication

### DIFF
--- a/src/de/diddiz/LogBlock/Tool.java
+++ b/src/de/diddiz/LogBlock/Tool.java
@@ -10,17 +10,19 @@ public class Tool
 	public final ToolBehavior leftClickBehavior, rightClickBehavior;
 	public final boolean defaultEnabled;
 	public final int item;
+	public final boolean canDrop;
 	public final QueryParams params;
 	public final ToolMode mode;
 	public final PermissionDefault permissionDefault;
 
-	public Tool(String name, List<String> aliases, ToolBehavior leftClickBehavior, ToolBehavior rightClickBehavior, boolean defaultEnabled, int item, QueryParams params, ToolMode mode, PermissionDefault permissionDefault) {
+	public Tool(String name, List<String> aliases, ToolBehavior leftClickBehavior, ToolBehavior rightClickBehavior, boolean defaultEnabled, int item, boolean canDrop, QueryParams params, ToolMode mode, PermissionDefault permissionDefault) {
 		this.name = name;
 		this.aliases = aliases;
 		this.leftClickBehavior = leftClickBehavior;
 		this.rightClickBehavior = rightClickBehavior;
 		this.defaultEnabled = defaultEnabled;
 		this.item = item;
+		this.canDrop = canDrop;
 		this.params = params;
 		this.mode = mode;
 		this.permissionDefault = permissionDefault;

--- a/src/de/diddiz/LogBlock/config/Config.java
+++ b/src/de/diddiz/LogBlock/config/Config.java
@@ -109,6 +109,7 @@ public class Config
 		def.put("tools.tool.rightClickBehavior", "TOOL");
 		def.put("tools.tool.defaultEnabled", true);
 		def.put("tools.tool.item", 270);
+		def.put("tools.tool.canDrop", true);
 		def.put("tools.tool.params", "area 0 all sum none limit 15 desc silent");
 		def.put("tools.tool.mode", "LOOKUP");
 		def.put("tools.tool.permissionDefault", "TRUE");
@@ -117,6 +118,7 @@ public class Config
 		def.put("tools.toolblock.rightClickBehavior", "BLOCK");
 		def.put("tools.toolblock.defaultEnabled", true);
 		def.put("tools.toolblock.item", 7);
+		def.put("tools.toolblock.canDrop", false);
 		def.put("tools.toolblock.params", "area 0 all sum none limit 15 desc silent");
 		def.put("tools.toolblock.mode", "LOOKUP");
 		def.put("tools.toolblock.permissionDefault", "TRUE");
@@ -181,12 +183,13 @@ public class Config
 				final ToolBehavior rightClickBehavior = ToolBehavior.valueOf(tSec.getString("rightClickBehavior").toUpperCase());
 				final boolean defaultEnabled = tSec.getBoolean("defaultEnabled", false);
 				final int item = tSec.getInt("item", 0);
+				final boolean canDrop = tSec.getBoolean("canDrop", false);
 				final QueryParams params = new QueryParams(logblock);
 				params.prepareToolQuery = true;
 				params.parseArgs(getConsoleSender(), Arrays.asList(tSec.getString("params").split(" ")));
 				final ToolMode mode = ToolMode.valueOf(tSec.getString("mode").toUpperCase());
 				final PermissionDefault pdef = PermissionDefault.valueOf(tSec.getString("permissionDefault").toUpperCase());
-				tools.add(new Tool(toolName, aliases, leftClickBehavior, rightClickBehavior, defaultEnabled, item, params, mode, pdef));
+				tools.add(new Tool(toolName, aliases, leftClickBehavior, rightClickBehavior, defaultEnabled, item, canDrop, params, mode, pdef));
 			} catch (final Exception ex) {
 				getLogger().log(Level.WARNING, "Error at parsing tool '" + toolName + "': ", ex);
 			}

--- a/src/de/diddiz/LogBlock/listeners/ToolListener.java
+++ b/src/de/diddiz/LogBlock/listeners/ToolListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import com.sk89q.worldedit.bukkit.selections.CuboidSelection;
@@ -93,6 +94,23 @@ public class ToolListener implements Listener
 					toolData.enabled = false;
 					player.getInventory().removeItem(new ItemStack(tool.item, 1));
 					player.sendMessage(ChatColor.GREEN + "Tool disabled.");
+				}
+			}
+		}
+	}
+
+	@EventHandler
+	public void onPlayerDropItem(PlayerDropItemEvent event) {
+		final Player player = event.getPlayer();
+		if (hasSession(player)) {
+			final Session session = getSession(player);
+			for (final Entry<Tool, ToolData> entry : session.toolData.entrySet()) {
+				final Tool tool = entry.getKey();
+				final ToolData toolData = entry.getValue();
+				final int item = event.getItemDrop().getItemStack().getTypeId();
+				if (item == tool.item && toolData.enabled && !tool.canDrop) {
+					player.sendMessage(ChatColor.RED + "You cannot drop this tool.");
+					event.setCancelled(true);
 				}
 			}
 		}


### PR DESCRIPTION
Title says all, recently came across a macro on hackforums that automates rapidly using /lb toolblock and dropping the item.  This is a noticeable problem particularly with the default toolblock being bedrock.
