### PR TITLE
Added code to hide the LB plugin from users who have no permissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-/.classpath
-/.project
-/.settings
+.DS_Store
+.project
+.classpath
+*.class
+*.jar
+/libraries
 /bin
-/release
-/agitar
+/lib

--- a/src/de/diddiz/LogBlock/CommandsHandler.java
+++ b/src/de/diddiz/LogBlock/CommandsHandler.java
@@ -64,6 +64,16 @@ public class CommandsHandler implements CommandExecutor
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
 		try {
+			
+			if (!logblock.hasPermission(sender, "logblock.*") && !logblock.hasPermission(sender, "logblock.lookup")
+					&& !logblock.hasPermission(sender, "logblock.rollback") && !logblock.hasPermission(sender, "logblock.clearlog")
+					&& !logblock.hasPermission(sender, "logblock.hide") && !logblock.hasPermission(sender, "logblock.tp")
+					&& !logblock.hasPermission(sender, "logblock.me") && !logblock.hasPermission(sender, "logblock.ignoreRestrictions")
+					&& !logblock.hasPermission(sender, "logblock.spawnTools")){
+				sender.sendMessage("Unknown command. Type \"help\" for help.");
+				return true;
+			}
+			
 			if (args.length == 0) {
 				sender.sendMessage(ChatColor.LIGHT_PURPLE + "LogBlock v" + logblock.getDescription().getVersion() + " by DiddiZ");
 				if (checkVersion)


### PR DESCRIPTION
You have to specifically give them '-logblock.me' , '-logblock.spawnTools' & '-logblock.tools.*' for this to work. Otherwise the LB plugin provides them with these permissions by default.

I preferred regular users not know I am using this plugin if possible. I'm sure there are better ways to implement this, open to suggestions.
