### PR TITLE
Update to queueBlockReplace

### DIFF
--- a/src/de/diddiz/LogBlock/Consumer.java
+++ b/src/de/diddiz/LogBlock/Consumer.java
@@ -120,7 +120,7 @@ public class Consumer extends TimerTask
 	}
 
 	public void queueBlockReplace(String playerName, Location loc, int typeBefore, byte dataBefore, int typeAfter, byte dataAfter) {
-		if (dataBefore == 0)
+		if (dataBefore == 0 && (typeBefore != typeAfter))
 			queueBlock(playerName, loc, typeBefore, typeAfter, dataAfter);
 		else {
 			queueBlockBreak(playerName, loc, typeBefore, dataBefore);


### PR DESCRIPTION
Before if a block was replaced with another block of the same type but with different data, it would not log the event if the original data was 0.

Now it forces the two separate queueBlockBreak and queueBlockPlace calls in that condition.
