### PR TITLE
Fix orientation of stairs and beds in rollbacks

### DIFF
--- a/src/de/diddiz/LogBlock/listeners/BlockPlaceLogging.java
+++ b/src/de/diddiz/LogBlock/listeners/BlockPlaceLogging.java
@@ -2,6 +2,7 @@ package de.diddiz.LogBlock.listeners;
 
 import static de.diddiz.LogBlock.config.Config.getWorldConfig;
 import static de.diddiz.LogBlock.config.Config.isLogging;
+
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
@@ -26,11 +27,27 @@ public class BlockPlaceLogging extends LoggingListener
 			final int type = event.getBlock().getTypeId();
 			final BlockState before = event.getBlockReplacedState();
 			final BlockState after = event.getBlockPlaced().getState();
+			final String playerName = event.getPlayer().getName();
 			if (type == 0 && event.getItemInHand() != null) {
 				if (event.getItemInHand().getTypeId() == 51)
 					return;
 				after.setTypeId(event.getItemInHand().getTypeId());
 				after.setData(new MaterialData(event.getItemInHand().getTypeId()));
+			}
+			// Delay queuing of stairs and blocks by 1 tick to allow the raw data to update 
+			if (type == 53 || type == 67 || type == 108 || type == 109 || type == 114 || type == 128 || type == 134 || type == 135 || type == 136 || type == 26) {
+				LogBlock.getInstance().getServer().getScheduler().scheduleSyncDelayedTask(LogBlock.getInstance(), new Runnable() {
+					
+					@Override
+					public void run() {
+						if (before.getTypeId() == 0)
+							consumer.queueBlockPlace(playerName, after);
+						else
+							consumer.queueBlockReplace(playerName, before, after);
+					}
+					
+				}, 1L);
+				return;
 			}
 			if (wcfg.isLogging(Logging.SIGNTEXT) && (type == 63 || type == 68))
 				return;


### PR DESCRIPTION
Essentially right now the data in the BlockState isn't updated during the BlockPlaceEvent for some reason, so until this is resolved internally in craftbukkit this should fix it in LogBlock with no side effects
