### PR TITLE
Fix duplicate log bits

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/CommandsHandler.java
+++ b/src/main/java/de/diddiz/LogBlock/CommandsHandler.java
@@ -318,7 +318,7 @@ public class CommandsHandler implements CommandExecutor
 			sender.sendMessage(ChatColor.RED + ex.getMessage());
 		} catch (final Exception ex) {
 			sender.sendMessage(ChatColor.RED + "Error, check server.log");
-			getLogger().log(Level.WARNING, "[LogBlock] Exception in commands handler: ", ex);
+			getLogger().log(Level.WARNING, "Exception in commands handler: ", ex);
 		}
 		return true;
 	}
@@ -383,7 +383,7 @@ public class CommandsHandler implements CommandExecutor
 				if (rs != null)
 					rs.close();
 			} catch (final SQLException ex) {
-				getLogger().log(Level.SEVERE, "[LogBlock CommandsHandler] SQL exception on close", ex);
+				getLogger().log(Level.SEVERE, "[CommandsHandler] SQL exception on close", ex);
 			}
 		}
 	}
@@ -437,7 +437,7 @@ public class CommandsHandler implements CommandExecutor
 				}
 			} catch (final Exception ex) {
 				sender.sendMessage(ChatColor.RED + "Exception, check error log");
-				getLogger().log(Level.SEVERE, "[LogBlock Lookup] " + params.getQuery() + ": ", ex);
+				getLogger().log(Level.SEVERE, "[Lookup] " + params.getQuery() + ": ", ex);
 			} finally {
 				close();
 			}
@@ -494,7 +494,7 @@ public class CommandsHandler implements CommandExecutor
 				sender.sendMessage(ChatColor.GREEN + "Wrote " + counter + " lines.");
 			} catch (final Exception ex) {
 				sender.sendMessage(ChatColor.RED + "Exception, check error log");
-				getLogger().log(Level.SEVERE, "[LogBlock WriteLogFile] " + params.getQuery() + " (file was " + file.getAbsolutePath() + "): ", ex);
+				getLogger().log(Level.SEVERE, "[WriteLogFile] " + params.getQuery() + " (file was " + file.getAbsolutePath() + "): ", ex);
 			} finally {
 				close();
 			}
@@ -568,7 +568,7 @@ public class CommandsHandler implements CommandExecutor
 					sender.sendMessage(ChatColor.RED + "No block change found to teleport to");
 			} catch (final Exception ex) {
 				sender.sendMessage(ChatColor.RED + "Exception, check error log");
-				getLogger().log(Level.SEVERE, "[LogBlock Teleport] " + params.getQuery() + ": ", ex);
+				getLogger().log(Level.SEVERE, "[Teleport] " + params.getQuery() + ": ", ex);
 			} finally {
 				close();
 			}
@@ -632,7 +632,7 @@ public class CommandsHandler implements CommandExecutor
 				}
 			} catch (final Exception ex) {
 				sender.sendMessage(ChatColor.RED + "Exception, check error log");
-				getLogger().log(Level.SEVERE, "[LogBlock Rollback] " + params.getQuery() + ": ", ex);
+				getLogger().log(Level.SEVERE, "[Rollback] " + params.getQuery() + ": ", ex);
 			} finally {
 				close();
 			}
@@ -685,7 +685,7 @@ public class CommandsHandler implements CommandExecutor
 				sender.sendMessage(ChatColor.GREEN + "Redo finished successfully (" + editor.getElapsedTime() + " ms, " + editor.getSuccesses() + "/" + changes + " blocks" + (editor.getErrors() > 0 ? ", " + ChatColor.RED + editor.getErrors() + " errors" + ChatColor.GREEN : "") + (editor.getBlacklistCollisions() > 0 ? ", " + editor.getBlacklistCollisions() + " blacklist collisions" : "") + ")");
 			} catch (final Exception ex) {
 				sender.sendMessage(ChatColor.RED + "Exception, check error log");
-				getLogger().log(Level.SEVERE, "[LogBlock Redo] " + params.getQuery() + ": ", ex);
+				getLogger().log(Level.SEVERE, "[Redo] " + params.getQuery() + ": ", ex);
 			} finally {
 				close();
 			}
@@ -732,7 +732,7 @@ public class CommandsHandler implements CommandExecutor
 							state.execute("SELECT * FROM `" + table + "` " + join + params.getWhere() + "INTO OUTFILE '" + new File(dumpFolder, time + " " + table + " " + params.getTitle().replace(":", ".") + ".csv").getAbsolutePath().replace("\\", "\\\\") + "' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"'  LINES TERMINATED BY '\n'");
 						} catch (final SQLException ex) {
 							sender.sendMessage(ChatColor.RED + "Error while dumping log. Make sure your MySQL user has access to the LogBlock folder, or disable clearlog.dumpDeletedLog");
-							getLogger().log(Level.SEVERE, "[LogBlock ClearLog] Exception while dumping log: ", ex);
+							getLogger().log(Level.SEVERE, "[ClearLog] Exception while dumping log: ", ex);
 							return;
 						}
 					state.execute("DELETE `" + table + "` FROM `" + table + "` " + join + params.getWhere());
@@ -756,7 +756,7 @@ public class CommandsHandler implements CommandExecutor
 				}
 			} catch (final Exception ex) {
 				sender.sendMessage(ChatColor.RED + "Exception, check error log");
-				getLogger().log(Level.SEVERE, "[LogBlock ClearLog] Exception: ", ex);
+				getLogger().log(Level.SEVERE, "[ClearLog] Exception: ", ex);
 			} finally {
 				close();
 			}

--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -273,7 +273,7 @@ public class Consumer extends TimerTask
 		final Connection conn = logblock.getConnection();
 		Statement state = null;
 		if (getQueueSize() > 1000)
-			getLogger().info("[LogBlock Consumer] Queue overloaded. Size: " + getQueueSize());
+			getLogger().info("[Consumer] Queue overloaded. Size: " + getQueueSize());
 		try {
 			if (conn == null)
 				return;
@@ -291,7 +291,7 @@ public class Consumer extends TimerTask
 						if (!addPlayer(state, player)) {
 							if (!failedPlayers.contains(player)) {
 								failedPlayers.add(player);
-								getLogger().warning("[LogBlock Consumer] Failed to add player " + player);
+								getLogger().warning("[Consumer] Failed to add player " + player);
 							}
 							continue process;
 						}
@@ -299,14 +299,14 @@ public class Consumer extends TimerTask
 					try {
 						state.execute(insert);
 					} catch (final SQLException ex) {
-						getLogger().log(Level.SEVERE, "[LogBlock Consumer] SQL exception on " + insert + ": ", ex);
+						getLogger().log(Level.SEVERE, "[Consumer] SQL exception on " + insert + ": ", ex);
 						break process;
 					}
 				count++;
 			}
 			conn.commit();
 		} catch (final SQLException ex) {
-			getLogger().log(Level.SEVERE, "[LogBlock Consumer] SQL exception", ex);
+			getLogger().log(Level.SEVERE, "[Consumer] SQL exception", ex);
 		} finally {
 			try {
 				if (state != null)
@@ -314,7 +314,7 @@ public class Consumer extends TimerTask
 				if (conn != null)
 					conn.close();
 			} catch (final SQLException ex) {
-				getLogger().log(Level.SEVERE, "[LogBlock Consumer] SQL exception on close", ex);
+				getLogger().log(Level.SEVERE, "[Consumer] SQL exception on close", ex);
 			}
 			lock.unlock();
 		}

--- a/src/main/java/de/diddiz/LogBlock/DumpedLogImporter.java
+++ b/src/main/java/de/diddiz/LogBlock/DumpedLogImporter.java
@@ -25,7 +25,7 @@ public class DumpedLogImporter implements Runnable
 	public void run() {
 		final File[] imports = new File("plugins/LogBlock/import/").listFiles(new ExtensionFilenameFilter("sql"));
 		if (imports != null && imports.length > 0) {
-			getLogger().info("[LogBlock] Found " + imports.length + " imports.");
+			getLogger().info("Found " + imports.length + " imports.");
 			Connection conn = null;
 			try {
 				conn = logblock.getConnection();
@@ -36,7 +36,7 @@ public class DumpedLogImporter implements Runnable
 				final BufferedWriter writer = new BufferedWriter(new FileWriter(new File(logblock.getDataFolder(), "import/failed.txt")));
 				int successes = 0, errors = 0;
 				for (final File sqlFile : imports) {
-					getLogger().info("[LogBlock] Trying to import " + sqlFile.getName() + " ...");
+					getLogger().info("Trying to import " + sqlFile.getName() + " ...");
 					final BufferedReader reader = new BufferedReader(new FileReader(sqlFile));
 					String line = null;
 					while ((line = reader.readLine()) != null)
@@ -44,20 +44,20 @@ public class DumpedLogImporter implements Runnable
 							st.execute(line);
 							successes++;
 						} catch (final Exception ex) {
-							getLogger().warning("[LogBlock] Error while importing: '" + line + "': " + ex.getMessage());
+							getLogger().warning("Error while importing: '" + line + "': " + ex.getMessage());
 							writer.write(line + newline);
 							errors++;
 						}
 					conn.commit();
 					reader.close();
 					sqlFile.delete();
-					getLogger().info("[LogBlock] Successfully imported " + sqlFile.getName() + ".");
+					getLogger().info("Successfully imported " + sqlFile.getName() + ".");
 				}
 				writer.close();
 				st.close();
-				getLogger().info("[LogBlock] Successfully imported stored queue. (" + successes + " rows imported, " + errors + " errors)");
+				getLogger().info("Successfully imported stored queue. (" + successes + " rows imported, " + errors + " errors)");
 			} catch (final Exception ex) {
-				getLogger().log(Level.WARNING, "[LogBlock] Error while importing: ", ex);
+				getLogger().log(Level.WARNING, "Error while importing: ", ex);
 			} finally {
 				if (conn != null)
 					try {

--- a/src/main/java/de/diddiz/LogBlock/LogBlock.java
+++ b/src/main/java/de/diddiz/LogBlock/LogBlock.java
@@ -83,7 +83,7 @@ public class LogBlock extends JavaPlugin
 		try {
 			updater = new Updater(this);
 			Config.load(this);
-			getLogger().info("[LogBlock] Connecting to " + user + "@" + url + "...");
+			getLogger().info("Connecting to " + user + "@" + url + "...");
 			pool = new MySQLConnectionPool(url, user, password);
 			final Connection conn = getConnection();
 			if (conn == null) {
@@ -95,9 +95,9 @@ public class LogBlock extends JavaPlugin
 				load(this);
 			updater.checkTables();
 		} catch (final NullPointerException ex) {
-			getLogger().log(Level.SEVERE, "[LogBlock] Error while loading: ", ex);
+			getLogger().log(Level.SEVERE, "Error while loading: ", ex);
 		} catch (final Exception ex) {
-			getLogger().severe("[LogBlock] Error while loading: " + ex.getMessage());
+			getLogger().severe("Error while loading: " + ex.getMessage());
 			errorAtLoading = true;
 			return;
 		}
@@ -126,16 +126,16 @@ public class LogBlock extends JavaPlugin
 		registerEvents();
 		if (useBukkitScheduler) {
 			if (getServer().getScheduler().scheduleAsyncRepeatingTask(this, consumer, delayBetweenRuns * 20, delayBetweenRuns * 20) > 0)
-				getLogger().info("[LogBlock] Scheduled consumer with bukkit scheduler.");
+				getLogger().info("Scheduled consumer with bukkit scheduler.");
 			else {
-				getLogger().warning("[LogBlock] Failed to schedule consumer with bukkit scheduler. Now trying schedule with timer.");
+				getLogger().warning("Failed to schedule consumer with bukkit scheduler. Now trying schedule with timer.");
 				timer = new Timer();
 				timer.scheduleAtFixedRate(consumer, delayBetweenRuns * 1000, delayBetweenRuns * 1000);
 			}
 		} else {
 			timer = new Timer();
 			timer.scheduleAtFixedRate(consumer, delayBetweenRuns * 1000, delayBetweenRuns * 1000);
-			getLogger().info("[LogBlock] Scheduled consumer with timer.");
+			getLogger().info("Scheduled consumer with timer.");
 		}
 		for (final Tool tool : toolsByType.values())
 			if (pm.getPermission("logblock.tools." + tool.name) == null) {
@@ -200,12 +200,12 @@ public class LogBlock extends JavaPlugin
 				for (final Player player : getServer().getOnlinePlayers())
 					consumer.queueLeave(player);
 			if (consumer.getQueueSize() > 0) {
-				getLogger().info("[LogBlock] Waiting for consumer ...");
+				getLogger().info("Waiting for consumer ...");
 				int tries = 10;
 				while (consumer.getQueueSize() > 0) {
-					getLogger().info("[LogBlock] Remaining queue size: " + consumer.getQueueSize());
+					getLogger().info("Remaining queue size: " + consumer.getQueueSize());
 					if (tries > 0)
-						getLogger().info("[LogBlock] Remaining tries: " + tries);
+						getLogger().info("Remaining tries: " + tries);
 					else {
 						getLogger().info("Unable to save queue to database. Trying to write to a local file.");
 						try {
@@ -223,7 +223,6 @@ public class LogBlock extends JavaPlugin
 		}
 		if (pool != null)
 			pool.close();
-		getLogger().info("LogBlock disabled.");
 	}
 
 	@Override
@@ -241,16 +240,16 @@ public class LogBlock extends JavaPlugin
 		try {
 			final Connection conn = pool.getConnection();
 			if (!connected) {
-				getLogger().info("[LogBlock] MySQL connection rebuild");
+				getLogger().info("MySQL connection rebuild");
 				connected = true;
 			}
 			return conn;
 		} catch (final Exception ex) {
 			if (connected) {
-				getLogger().log(Level.SEVERE, "[LogBlock] Error while fetching connection: ", ex);
+				getLogger().log(Level.SEVERE, "Error while fetching connection: ", ex);
 				connected = false;
 			} else
-				getLogger().severe("[LogBlock] MySQL connection lost");
+				getLogger().severe("MySQL connection lost");
 			return null;
 		}
 	}

--- a/src/main/java/de/diddiz/LogBlock/Updater.java
+++ b/src/main/java/de/diddiz/LogBlock/Updater.java
@@ -30,7 +30,7 @@ class Updater
 		if (config.getString("version").compareTo(logblock.getDescription().getVersion()) >= 0)
 			return false;
 		if (config.getString("version").compareTo("1.27") < 0) {
-			getLogger().info("[LogBlock] Updating tables to 1.27 ...");
+			getLogger().info("Updating tables to 1.27 ...");
 			if (isLogging(Logging.CHAT)) {
 				final Connection conn = logblock.getConnection();
 				try {
@@ -40,21 +40,21 @@ class Updater
 					st.close();
 					conn.close();
 				} catch (final SQLException ex) {
-					Bukkit.getLogger().log(Level.SEVERE, "[LogBlock Updater] Error: ", ex);
+					Bukkit.getLogger().log(Level.SEVERE, "[Updater] Error: ", ex);
 					return false;
 				}
 			}
 			config.set("version", "1.27");
 		}
 		if (config.getString("version").compareTo("1.30") < 0) {
-			getLogger().info("[LogBlock] Updating config to 1.30 ...");
+			getLogger().info("Updating config to 1.30 ...");
 			for (final String tool : config.getConfigurationSection("tools").getKeys(false))
 				if (config.get("tools." + tool + ".permissionDefault") == null)
 					config.set("tools." + tool + ".permissionDefault", "OP");
 			config.set("version", "1.30");
 		}
 		if (config.getString("version").compareTo("1.31") < 0) {
-			getLogger().info("[LogBlock] Updating tables to 1.31 ...");
+			getLogger().info("Updating tables to 1.31 ...");
 			final Connection conn = logblock.getConnection();
 			try {
 				conn.setAutoCommit(true);
@@ -63,13 +63,13 @@ class Updater
 				st.close();
 				conn.close();
 			} catch (final SQLException ex) {
-				Bukkit.getLogger().log(Level.SEVERE, "[LogBlock Updater] Error: ", ex);
+				Bukkit.getLogger().log(Level.SEVERE, "[Updater] Error: ", ex);
 				return false;
 			}
 			config.set("version", "1.31");
 		}
 		if (config.getString("version").compareTo("1.32") < 0) {
-			getLogger().info("[LogBlock] Updating tables to 1.32 ...");
+			getLogger().info("Updating tables to 1.32 ...");
 			final Connection conn = logblock.getConnection();
 			try {
 				conn.setAutoCommit(true);
@@ -78,18 +78,18 @@ class Updater
 				st.close();
 				conn.close();
 			} catch (final SQLException ex) {
-				Bukkit.getLogger().log(Level.SEVERE, "[LogBlock Updater] Error: ", ex);
+				Bukkit.getLogger().log(Level.SEVERE, "[Updater] Error: ", ex);
 				return false;
 			}
 			config.set("version", "1.32");
 		}
 		if (config.getString("version").compareTo("1.40") < 0) {
-			getLogger().info("[LogBlock] Updating config to 1.40 ...");
+			getLogger().info("Updating config to 1.40 ...");
 			config.set("clearlog.keepLogDays", null);
 			config.set("version", "1.40");
 		}
 		if (config.getString("version").compareTo("1.42") < 0) {
-			getLogger().info("[LogBlock] Updating config to 1.42 ...");
+			getLogger().info("Updating config to 1.42 ...");
 			for (final String world : config.getStringList("loggedWorlds")) {
 				final File file = new File(logblock.getDataFolder(), friendlyWorldname(world) + ".yml");
 				final YamlConfiguration wcfg = YamlConfiguration.loadConfiguration(file);
@@ -152,14 +152,14 @@ class Updater
 				try {
 					wcfg.save(file);
 				} catch (final IOException ex) {
-					Bukkit.getLogger().log(Level.SEVERE, "[LogBlock Updater] Error: ", ex);
+					Bukkit.getLogger().log(Level.SEVERE, "[Updater] Error: ", ex);
 				}
 			}
 			config.set("clearlog.keepLogDays", null);
 			config.set("version", "1.42");
 		}
 		if (config.getString("version").compareTo("1.51") < 0) {
-			getLogger().info("[LogBlock] Updating tables to 1.51 ...");
+			getLogger().info("Updating tables to 1.51 ...");
 			final Connection conn = logblock.getConnection();
 			try {
 				conn.setAutoCommit(true);
@@ -170,13 +170,13 @@ class Updater
 				st.close();
 				conn.close();
 			} catch (final SQLException ex) {
-				Bukkit.getLogger().log(Level.SEVERE, "[LogBlock Updater] Error: ", ex);
+				Bukkit.getLogger().log(Level.SEVERE, "[Updater] Error: ", ex);
 				return false;
 			}
 			config.set("version", "1.51");
 		}
 		if (config.getString("version").compareTo("1.52") < 0) {
-			getLogger().info("[LogBlock] Updating tables to 1.52 ...");
+			getLogger().info("Updating tables to 1.52 ...");
 			final Connection conn = logblock.getConnection();
 			try {
 				conn.setAutoCommit(true);
@@ -188,11 +188,11 @@ class Updater
 					st.execute("ALTER TABLE `lb-players` DROP onlinetime");
 					st.execute("ALTER TABLE `lb-players` CHANGE onlinetime2 onlinetime INT UNSIGNED NOT NULL");
 				} else
-					getLogger().info("[LogBlock] Column lb-players was alredy modified, skipping it.");
+					getLogger().info("Column lb-players was already modified, skipping it.");
 				st.close();
 				conn.close();
 			} catch (final SQLException ex) {
-				Bukkit.getLogger().log(Level.SEVERE, "[LogBlock Updater] Error: ", ex);
+				Bukkit.getLogger().log(Level.SEVERE, "[Updater] Error: ", ex);
 				return false;
 			}
 			config.set("version", "1.52");
@@ -224,7 +224,7 @@ class Updater
 
 	private static void createTable(DatabaseMetaData dbm, Statement state, String table, String query) throws SQLException {
 		if (!dbm.getTables(null, null, table, null).next()) {
-			getLogger().log(Level.INFO, "[LogBlock] Creating table " + table + ".");
+			getLogger().log(Level.INFO, "Creating table " + table + ".");
 			state.execute("CREATE TABLE `" + table + "` " + query);
 			if (!dbm.getTables(null, null, table, null).next())
 				throw new SQLException("Table " + table + " not found and failed to create");

--- a/src/main/java/de/diddiz/LogBlock/WorldEditor.java
+++ b/src/main/java/de/diddiz/LogBlock/WorldEditor.java
@@ -95,7 +95,7 @@ public class WorldEditor implements Runnable
 			} catch (final WorldEditorException ex) {
 				errorList.add(ex);
 			} catch (final Exception ex) {
-				getLogger().log(Level.WARNING, "[LogBlock WorldEditor] Exeption: ", ex);
+				getLogger().log(Level.WARNING, "[WorldEditor] Exeption: ", ex);
 			}
 			counter++;
 		}


### PR DESCRIPTION
Removes log prefixes as this is now in Bukkit's logging system and
frankly, looks ugly in the log file and console.
Removes duplicate disable message as this is not required due to
Bukkit's forced, auto-log of plugin enables, disables and loads.
