### PR TITLE
Put max area limit on a lookup

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/QueryParams.java
+++ b/src/main/java/de/diddiz/LogBlock/QueryParams.java
@@ -2,6 +2,7 @@ package de.diddiz.LogBlock;
 
 import de.diddiz.util.Block;
 import de.diddiz.worldedit.RegionContainer;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -572,7 +573,12 @@ public final class QueryParams implements Cloneable
 				} else {
 					if (!isInt(values[0]))
 						throw new IllegalArgumentException("Not a number: '" + values[0] + "'");
-					radius = Integer.parseInt(values[0]);
+					int requestedRadius = Integer.parseInt(values[0]);
+					if ( requestedRadius > maxAreaCap && !logblock.hasPermission(player, "logblock.noAreaCap")) {
+						sender.sendMessage(ChatColor.RED + "Overriding area " + requestedRadius + " to max allowed area of " + maxAreaCap);
+						requestedRadius = maxAreaCap;
+					}
+					radius = requestedRadius;
 					if (!prepareToolQuery)
 						loc = player.getLocation();
 				}

--- a/src/main/java/de/diddiz/LogBlock/config/Config.java
+++ b/src/main/java/de/diddiz/LogBlock/config/Config.java
@@ -37,7 +37,7 @@ public class Config
 	public static int rollbackMaxTime, rollbackMaxArea;
 	public static Map<String, Tool> toolsByName;
 	public static Map<Integer, Tool> toolsByType;
-	public static int defaultDist, defaultTime;
+	public static int defaultDist, defaultTime, maxAreaCap;
 	public static int linesPerPage, linesLimit;
 	public static boolean askRollbacks, askRedos, askClearLogs, askClearLogAfterRollback, askRollbackAfterBan;
 	public static String banPermission;
@@ -92,6 +92,7 @@ public class Config
 		def.put("rollback.maxArea", 50);
 		def.put("lookup.defaultDist", 20);
 		def.put("lookup.defaultTime", "30 minutes");
+		def.put("lookup.maxAreaCap", 20);
 		def.put("lookup.linesPerPage", 15);
 		def.put("lookup.linesLimit", 1500);
 		try {
@@ -170,6 +171,7 @@ public class Config
 		rollbackMaxArea = config.getInt("rollback.maxArea", 50);
 		defaultDist = config.getInt("lookup.defaultDist", 20);
 		defaultTime = parseTimeSpec(config.getString("lookup.defaultTime").split(" "));
+		maxAreaCap = config.getInt("lookup.maxAreaCap", 20);
 		linesPerPage = config.getInt("lookup.linesPerPage", 15);
 		linesLimit = config.getInt("lookup.linesLimit", 1500);
 		askRollbacks = config.getBoolean("questioner.askRollbacks", true);


### PR DESCRIPTION
Add the ability to restrict the maximum area/radius on a lookup. Can be overridden with logblock.noAreaCap permission node.
