### PR TITLE
Use unix timestamps in queries.

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -464,8 +464,8 @@ public class Consumer extends TimerTask
 			PreparedStatement ps1 = null;
 			PreparedStatement ps = null;
 			try {
-				ps1 = connection.prepareStatement("INSERT INTO `" + table + "` (date, playerid, replaced, type, data, x, y, z) VALUES(?, " + playerID(playerName) + ", ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
-				ps1.setTimestamp(1, new Timestamp(date * 1000));
+				ps1 = connection.prepareStatement("INSERT INTO `" + table + "` (date, playerid, replaced, type, data, x, y, z) VALUES(FROM_UNIXTIME(?), " + playerID(playerName) + ", ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
+				ps1.setLong(1, date );
 				ps1.setInt(2, replaced);
 				ps1.setInt(3, type);
 				ps1.setInt(4, data);
@@ -574,7 +574,7 @@ public class Consumer extends TimerTask
 			boolean noID = false;
 			Integer id;
 
-			String sql = "INSERT INTO `lb-chat` (date, playerid, message) VALUES (?, ";
+			String sql = "INSERT INTO `lb-chat` (date, playerid, message) VALUES (FROM_UNIXTIME(?), ";
 			if ((id = playerIDAsInt(playerName)) == null) {
 				noID = true;
 				sql += playerID(playerName) + ", ";
@@ -586,7 +586,7 @@ public class Consumer extends TimerTask
 			PreparedStatement ps = null;
 			try {
 				ps = connection.prepareStatement(sql);
-				ps.setTimestamp(1, new Timestamp(date * 1000));
+				ps.setLong(1, date);
 				if (!noID) {
 					ps.setInt(2, id);
 					ps.setString(3, message);


### PR DESCRIPTION
Fixes #339 ( #312 #328 ) by using FROM_UNIXTIME in the query even if using the paramaterised version, as java timestamps are not timezone-aware.  Also fixed the same thing in the chat insert.

My current minecraft test server timezone is UTC+1 (UK summer time).  I set my test MySQL server to UTC+2 and did the following tests.

Before change:
![2013-06-07_15 56 22](https://f.cloud.github.com/assets/426814/624553/0fb20e4e-cf88-11e2-8e22-6d8ccf141e37.png)

After change:
![2013-06-07_16 22 08](https://f.cloud.github.com/assets/426814/624555/1dc8117c-cf88-11e2-8e91-4a4e165a477e.png)

(times mentioned in chat are from the minecraft server's perspective)
