### PR TITLE
Make projectile kills traceable

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -171,12 +171,11 @@ public class Consumer extends TimerTask
 		int weapon = 0;
                 
                 if(killer instanceof Projectile)
-                    killer = ((Projectile)killer).getShooter();
-                
+			killer = ((Projectile)killer).getShooter();
+		
 		if (killer instanceof Player && ((Player)killer).getItemInHand() != null)
 			weapon = ((Player)killer).getItemInHand().getTypeId();
-                
-                
+		
 		queueKill(victim.getLocation(), entityName(killer), entityName(victim), weapon);
 	}
 

--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import static de.diddiz.LogBlock.config.Config.*;
 import static de.diddiz.util.BukkitUtils.*;
 import static org.bukkit.Bukkit.getLogger;
+import org.bukkit.entity.Projectile;
 
 public class Consumer extends TimerTask
 {
@@ -168,8 +169,14 @@ public class Consumer extends TimerTask
 		if (killer == null || victim == null)
 			return;
 		int weapon = 0;
+                
+                if(killer instanceof Projectile)
+                    killer = ((Projectile)killer).getShooter();
+                
 		if (killer instanceof Player && ((Player)killer).getItemInHand() != null)
 			weapon = ((Player)killer).getItemInHand().getTypeId();
+                
+                
 		queueKill(victim.getLocation(), entityName(killer), entityName(victim), weapon);
 	}
 

--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -8,6 +8,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -25,7 +26,6 @@ import java.util.logging.Level;
 import static de.diddiz.LogBlock.config.Config.*;
 import static de.diddiz.util.BukkitUtils.*;
 import static org.bukkit.Bukkit.getLogger;
-import org.bukkit.entity.Projectile;
 
 public class Consumer extends TimerTask
 {


### PR DESCRIPTION
This pull request fixes an issue in which kills with a Projectile entity are not traceable. Instead of the arrow or other projectile being registered as the killer, the shooter of the projectile will be.