### PR TITLE
More specific information when no params/args specified

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/CommandsHandler.java
+++ b/src/main/java/de/diddiz/LogBlock/CommandsHandler.java
@@ -306,6 +306,8 @@ public class CommandsHandler implements CommandExecutor
 			}
 		} catch (final IllegalArgumentException ex) {
 			sender.sendMessage(ChatColor.RED + ex.getMessage());
+		} catch (final ArrayIndexOutOfBoundsException ex) {
+			sender.sendMessage(ChatColor.RED + "Not enough arguments given");
 		} catch (final Exception ex) {
 			sender.sendMessage(ChatColor.RED + "Error, check server.log");
 			getLogger().log(Level.WARNING, "Exception in commands handler: ", ex);


### PR DESCRIPTION
This commit adds the `ArrayIndexOutOfBoundsException` to onCommand's exception-catcher. This is so the user gets more specific information than "Error, check server.log" when they don't give any arguments.

Now, the user will receive "Not enough arguments given", which is a far more accurate and user-friendly error than "Error, check server.log" (which leads to "java.lang.ArrayIndexOutOfBoundsException: 1" in server.log).
