### PR TITLE
Expand chestaccess querying

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/CommandsHandler.java
+++ b/src/main/java/de/diddiz/LogBlock/CommandsHandler.java
@@ -406,7 +406,7 @@ public class CommandsHandler implements CommandExecutor
 					params.needPlayer = true;
 					if (params.types.isEmpty() || Block.inList(params.types, 63) || Block.inList(params.types, 68))
 						params.needSignText = true;
-					if (params.bct == BlockChangeType.CHESTACCESS || params.types.isEmpty() || Block.inList(params.types, 23) || Block.inList(params.types, 54) || Block.inList(params.types, 61) || Block.inList(params.types, 62))
+					if (params.bct == BlockChangeType.CHESTACCESS || params.bct == BlockChangeType.ALL)
 						params.needChestAccess = true;
 				}
 				conn = logblock.getConnection();
@@ -466,7 +466,7 @@ public class CommandsHandler implements CommandExecutor
 					params.needPlayer = true;
 					if (params.types.isEmpty() || Block.inList(params.types, 63) || Block.inList(params.types, 68))
 						params.needSignText = true;
-					if (params.types.isEmpty() || Block.inList(params.types, 23) || Block.inList(params.types, 54) || Block.inList(params.types, 61) || Block.inList(params.types, 62))
+					if (params.bct == BlockChangeType.CHESTACCESS || params.bct == BlockChangeType.ALL)
 						params.needChestAccess = true;
 				}
 				conn = logblock.getConnection();
@@ -538,9 +538,8 @@ public class CommandsHandler implements CommandExecutor
 		public void run() {
 			try {
 				params.needCoords = true;
-				if (params.bct == BlockChangeType.CHESTACCESS || params.types.isEmpty() || Block.inList(params.types, 23) || Block.inList(params.types, 54) || Block.inList(params.types, 61) || Block.inList(params.types, 62)) {
+				if (params.bct == BlockChangeType.CHESTACCESS || params.bct == BlockChangeType.ALL)
 					params.needChestAccess = true;
-				}
 				params.limit = 1;
 				params.sum = SummarizationMode.NONE;
 				conn = logblock.getConnection();

--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -120,7 +120,7 @@ public class Consumer extends TimerTask
 
 	/**
 	 * @param container
-	 * The respective container. Must be an instance of Chest, Dispencer or Furnace.
+	 * The respective container. Must be an instance of an InventoryHolder.
 	 */
 	public void queueChestAccess(String playerName, BlockState container, short itemType, short itemAmount, byte itemData) {
 		if (!(container instanceof InventoryHolder))
@@ -130,7 +130,7 @@ public class Consumer extends TimerTask
 
 	/**
 	 * @param type
-	 * Type id of the container. Must be 63 or 68.
+	 * Type id of the container.
 	 */
 	public void queueChestAccess(String playerName, Location loc, int type, short itemType, short itemAmount, byte itemData) {
 		queueBlock(playerName, loc, type, type, (byte)0, null, new ChestAccess(itemType, itemAmount, itemData));
@@ -140,7 +140,7 @@ public class Consumer extends TimerTask
 	 * Logs a container block break. The block type before is assumed to be o (air). All content is assumed to be taken.
 	 *
 	 * @param container
-	 * Must be instanceof InventoryHolder
+	 * Must be an instance of InventoryHolder
 	 */
 	public void queueContainerBreak(String playerName, BlockState container) {
 		if (!(container instanceof InventoryHolder))

--- a/src/main/java/de/diddiz/util/BukkitUtils.java
+++ b/src/main/java/de/diddiz/util/BukkitUtils.java
@@ -152,6 +152,8 @@ public class BukkitUtils
 		containerBlocks.add(Material.DROPPER);
 		containerBlocks.add(Material.HOPPER);
 		containerBlocks.add(Material.BREWING_STAND);
+		containerBlocks.add(Material.FURNACE);
+		containerBlocks.add(Material.BEACON);
 		// Doesn't actually have a block inventory
 		// containerBlocks.add(Material.ENDER_CHEST);
 	}


### PR DESCRIPTION
Make a decison on whether or not to return chest access data based on the BlockChangeType (ALL or CHESTACCESS) rather than partly on the block parameter as these are the only two query types that don't enforce type != replaced

This is helpful because the list of blocks to request chest access for was outdated and is duplicated in 3 different places, whereas the new method will return whatever results have been logged regardless of type.

In addition, if the query type is CHESTACCESS (but not ALL), we can use an alternate query that is vastly more efficient.  In tests (26 million row log table, 400,000 row chest table) the query time for all chest results
was reduced from 30 seconds to 3.

Allows the chestaccess parameter to return data from the following inventory types:
- Brewing stand
- Trapped chest (fixes #483)
- Dropper
- Hopper
- Beacon

Note that this only affects lookup of logged items; the logging process has not been touched, so #433 and similar have not been addressed

Also, update the list of valid container types, which will improve logging of broken containers (furnace and beacon)
