### PR TITLE
Implement logging for environmental (non-entity) kills

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/Consumer.java
+++ b/src/main/java/de/diddiz/LogBlock/Consumer.java
@@ -160,9 +160,9 @@ public class Consumer extends TimerTask
 
 	/**
 	 * @param killer
-	 * Can' be null
+	 * Can't be null
 	 * @param victim
-	 * Can' be null
+	 * Can't be null
 	 */
 	public void queueKill(Entity killer, Entity victim) {
 		if (killer == null || victim == null)
@@ -171,6 +171,19 @@ public class Consumer extends TimerTask
 		if (killer instanceof Player && ((Player)killer).getItemInHand() != null)
 			weapon = ((Player)killer).getItemInHand().getTypeId();
 		queueKill(victim.getLocation(), entityName(killer), entityName(victim), weapon);
+	}
+
+	/**
+	 * This form should only be used when the killer is not an entity e.g. for fall or suffocation damage
+	 * @param killer
+	 * Can't be null
+	 * @param victim
+	 * Can't be null
+	 */
+	public void queueKill(String killer, Entity victim) {
+		if (killer == null || victim == null)
+			return;
+		queueKill(victim.getLocation(), killer, entityName(victim), 0);
 	}
 
 	/**
@@ -539,7 +552,7 @@ public class Consumer extends TimerTask
 
 		@Override
 		public String[] getInserts() {
-			return new String[]{"INSERT INTO `" + getWorldConfig(loc.getWorld()).table + "-kills` (date, killer, victim, weapon, x, y, z) VALUES (FROM_UNIXTIME(" + date + "), " + playerID(killer) + ", " + playerID(victim) + ", " + weapon + ", " + loc.getBlockX() + ", " + loc.getBlockY() + ", " + loc.getBlockZ() + ");"};
+			return new String[]{"INSERT INTO `" + getWorldConfig(loc.getWorld()).table + "-kills` (date, killer, victim, weapon, x, y, z) VALUES (FROM_UNIXTIME(" + date + "), " + playerID(killer) + ", " + playerID(victim) + ", " + weapon + ", " + loc.getBlockX() + ", " + (loc.getBlockY() < 0 ? 0 : loc.getBlockY()) + ", " + loc.getBlockZ() + ");"};
 		}
 
 		@Override

--- a/src/main/java/de/diddiz/LogBlock/config/Config.java
+++ b/src/main/java/de/diddiz/LogBlock/config/Config.java
@@ -46,6 +46,7 @@ public class Config
 	public static Set<String> ignoredChat;
 	public static SimpleDateFormat formatter;
 	public static boolean safetyIdCheck;
+	public static boolean logEnvironmentalKills;
 
 	public static enum LogKillsLevel
 	{
@@ -82,6 +83,7 @@ public class Config
 		def.put("clearlog.autoClearLogDelay", "6h");
 		def.put("logging.logCreeperExplosionsAsPlayerWhoTriggeredThese", false);
 		def.put("logging.logKillsLevel", "PLAYERS");
+		def.put("logging.logEnvironmentalKills", false);
 		def.put("logging.logPlayerInfo", false);
 		def.put("logging.hiddenPlayers", new ArrayList<String>());
 		def.put("logging.hiddenBlocks", Arrays.asList(0));
@@ -149,6 +151,7 @@ public class Config
 		} catch (final IllegalArgumentException ex) {
 			throw new DataFormatException("logging.logKillsLevel doesn't appear to be a valid log level. Allowed are 'PLAYERS', 'MONSTERS' and 'ANIMALS'");
 		}
+		logEnvironmentalKills = config.getBoolean("logging.logEnvironmentalKills", false);
 		hiddenPlayers = new HashSet<String>();
 		for (final String playerName : config.getStringList("logging.hiddenPlayers"))
 			hiddenPlayers.add(playerName.toLowerCase().trim());

--- a/src/main/java/de/diddiz/LogBlock/listeners/KillLogging.java
+++ b/src/main/java/de/diddiz/LogBlock/listeners/KillLogging.java
@@ -2,6 +2,7 @@ package de.diddiz.LogBlock.listeners;
 
 import static de.diddiz.LogBlock.config.Config.isLogging;
 import static de.diddiz.LogBlock.config.Config.logKillsLevel;
+import static de.diddiz.LogBlock.config.Config.logEnvironmentalKills;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
@@ -15,6 +16,7 @@ import de.diddiz.LogBlock.LogBlock;
 import de.diddiz.LogBlock.Logging;
 import de.diddiz.LogBlock.config.Config.LogKillsLevel;
 
+
 public class KillLogging extends LoggingListener
 {
 
@@ -26,14 +28,22 @@ public class KillLogging extends LoggingListener
 	public void onEntityDeath(EntityDeathEvent deathEvent) {
 		EntityDamageEvent event = deathEvent.getEntity().getLastDamageCause();
 		// For a death event, there should always be a damage event and it should not be cancelled.  Check anyway.
-		if (event!= null && event.isCancelled() == false && isLogging(event.getEntity().getWorld(), Logging.KILL) && event instanceof EntityDamageByEntityEvent && event.getEntity() instanceof LivingEntity) {
+		if (event!= null && event.isCancelled() == false && isLogging(event.getEntity().getWorld(), Logging.KILL) && event.getEntity() instanceof LivingEntity) {
 			final LivingEntity victim = (LivingEntity)event.getEntity();
-			final Entity killer = ((EntityDamageByEntityEvent)event).getDamager();
-			if (logKillsLevel == LogKillsLevel.PLAYERS && !(victim instanceof Player && killer instanceof Player))
-				return;
-			else if (logKillsLevel == LogKillsLevel.MONSTERS && !((victim instanceof Player || victim instanceof Monster) && killer instanceof Player || killer instanceof Monster))
-				return;
-			consumer.queueKill(killer, victim);
+			if (event instanceof EntityDamageByEntityEvent) {
+				final Entity killer = ((EntityDamageByEntityEvent)event).getDamager();
+				if (logKillsLevel == LogKillsLevel.PLAYERS && !(victim instanceof Player && killer instanceof Player))
+					return;
+				else if (logKillsLevel == LogKillsLevel.MONSTERS && !((victim instanceof Player || victim instanceof Monster) && killer instanceof Player || killer instanceof Monster))
+					return;
+				consumer.queueKill(killer, victim);
+			} else if (logEnvironmentalKills) {
+				if (logKillsLevel == LogKillsLevel.PLAYERS && !(victim instanceof Player))
+					return;
+				else if (logKillsLevel == LogKillsLevel.MONSTERS && !((victim instanceof Player || victim instanceof Monster)))
+					return;
+				consumer.queueKill(event.getCause().toString(),victim);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds #80

This change adds a new config option, logEnvironmentalKills.  When set to true,
Logblock will record entity deaths not directly caused by another entity.
(for example, suffocation, or burning to death)

As this could be spammy (undead dying every morning, chicken murderdeathkill machines etc.) I'd appreciate a second (or third, or fourth....) opinion :)
