### PR TITLE
Improvements to checks for inventory blocks and double inventory blocks

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/WorldEditor.java
+++ b/src/main/java/de/diddiz/LogBlock/WorldEditor.java
@@ -10,6 +10,7 @@ import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
 import org.bukkit.material.Bed;
 import org.bukkit.material.PistonBaseMaterial;
 import org.bukkit.material.PistonExtensionMaterial;
@@ -26,6 +27,7 @@ import java.util.logging.Level;
 import static de.diddiz.LogBlock.config.Config.dontRollback;
 import static de.diddiz.LogBlock.config.Config.replaceAnyway;
 import static de.diddiz.util.BukkitUtils.equalTypes;
+import static de.diddiz.util.BukkitUtils.getContainerBlocks;
 import static de.diddiz.util.BukkitUtils.modifyContainer;
 import static de.diddiz.util.MaterialName.materialName;
 import static org.bukkit.Bukkit.getLogger;
@@ -162,13 +164,13 @@ public class WorldEditor implements Runnable
 				if (type == 0) {
 					if (!block.setTypeId(0))
 						throw new WorldEditorException(block.getTypeId(), 0, block.getLocation());
-				} else if (ca != null ) {
-					boolean chest = (type == 54 || type == 146);
-					if (chest || type == 23 || type == 61 || type == 62) {
+				} else if (ca != null) {
+					if (getContainerBlocks().contains(Material.getMaterial(type))) {
 						int leftover;
 						try {
 							leftover = modifyContainer(state, new ItemStack(ca.itemType, -ca.itemAmount, ca.itemData));
-							if (leftover > 0 && chest)
+							// Special-case blocks which might be double chests
+							if (leftover > 0 && (type == 54 || type == 146))
 								for (final BlockFace face : new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST})
 									if (block.getRelative(face).getTypeId() == type)
 										leftover = modifyContainer(block.getRelative(face).getState(), new ItemStack(ca.itemType, ca.itemAmount < 0 ? leftover : -leftover, ca.itemData));

--- a/src/main/java/de/diddiz/LogBlock/listeners/ExplosionLogging.java
+++ b/src/main/java/de/diddiz/LogBlock/listeners/ExplosionLogging.java
@@ -18,9 +18,11 @@ import org.bukkit.entity.WitherSkull;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.Material;
 
 import static de.diddiz.LogBlock.config.Config.getWorldConfig;
 import static de.diddiz.LogBlock.config.Config.logCreeperExplosionsAsPlayerWhoTriggeredThese;
+import static de.diddiz.util.BukkitUtils.getContainerBlocks;
 
 public class ExplosionLogging extends LoggingListener
 {
@@ -90,7 +92,7 @@ public class ExplosionLogging extends LoggingListener
 				final int type = block.getTypeId();
 				if (wcfg.isLogging(Logging.SIGNTEXT) & (type == 63 || type == 68))
 					consumer.queueSignBreak(name, (Sign)block.getState());
-				else if (wcfg.isLogging(Logging.CHESTACCESS) && (type == 23 || type == 54 || type == 61))
+				else if (wcfg.isLogging(Logging.CHESTACCESS) && (getContainerBlocks().contains(Material.getMaterial(type))))
 					consumer.queueContainerBreak(name, block.getState());
 				else
 					consumer.queueBlockBreak(name, block.getState());

--- a/src/main/java/de/diddiz/LogBlock/listeners/ToolListener.java
+++ b/src/main/java/de/diddiz/LogBlock/listeners/ToolListener.java
@@ -60,12 +60,12 @@ public class ToolListener implements Listener
 					params.sel = null;
 					if (behavior == ToolBehavior.BLOCK)
 						params.setLocation(block.getRelative(event.getBlockFace()).getLocation());
-					else if (block.getTypeId() != 54 || tool.params.radius != 0)
+					else if ((block.getTypeId() != 54 && block.getTypeId() != 146) || tool.params.radius != 0)
 						params.setLocation(block.getLocation());
 					else {
 						if (logblock.getServer().getPluginManager().isPluginEnabled("WorldEdit")) {
 							for (final BlockFace face : new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST}) {
-								if (block.getRelative(face).getTypeId() == 54) {
+								if (block.getRelative(face).getTypeId() == block.getTypeId()) {
 									params.setSelection(RegionContainer.fromCorners(event.getPlayer().getWorld(),
 											block.getLocation(), block.getRelative(face).getLocation()));
 								}

--- a/src/main/java/de/diddiz/util/BukkitUtils.java
+++ b/src/main/java/de/diddiz/util/BukkitUtils.java
@@ -153,6 +153,7 @@ public class BukkitUtils
 		containerBlocks.add(Material.HOPPER);
 		containerBlocks.add(Material.BREWING_STAND);
 		containerBlocks.add(Material.FURNACE);
+		containerBlocks.add(Material.BURNING_FURNACE);
 		containerBlocks.add(Material.BEACON);
 		// Doesn't actually have a block inventory
 		// containerBlocks.add(Material.ENDER_CHEST);


### PR DESCRIPTION
Expanding on #510 these commits replace all checks of the form `type == someInventoryBlockId || type = anotherOne....` with a call to `getContainerBlocks().contains(Material.getMaterial(type))`

This was done by searching the code for `54` which is the chest ID.

Remaining explicit mentions of id 54 are in regards to special-casing for double chests - the code there has been expanded to also consider id 146, the trapped chest.  I didn't think it worth making a collection for double-block inventories, but if more are added it should be considered - looking forward, this might be necessary when the mod API comes in, assuming we have a way of figuring out what double inventories are anyway.

This fixes many blocks not having inventories logged when destroyed due to explosions, or not being rollbackable, and tools not querying both sides of double trapped chests.

Rolling back e.g. a furnace is glitchy - the fuel, raw material and product do not get placed in the correct slots.
