### PR TITLE
Updated for safer multithreading

### DIFF
--- a/src/main/java/de/diddiz/util/MySQLConnectionPool.java
+++ b/src/main/java/de/diddiz/util/MySQLConnectionPool.java
@@ -30,7 +30,7 @@ public class MySQLConnectionPool implements Closeable
 {
 	private final static int poolSize = 10;
 	private final static long timeToLive = 300000;
-	private final ArrayList<JDCConnection> connections;
+	private final Vector<JDCConnection> connections;
 	private final String url, user, password;
 	private final Lock lock = new ReentrantLock();
 
@@ -39,7 +39,7 @@ public class MySQLConnectionPool implements Closeable
 		this.url = url;
 		this.user = user;
 		this.password = password;
-		connections = new ArrayList<JDCConnection>(poolSize);
+		connections = new Vector<JDCConnection>(poolSize);
         ConnectionReaper reaper = new ConnectionReaper();
 		new Thread(reaper, "MySQL Connection Reaper Thread - LogBlock").start();
 	}

--- a/src/main/java/de/diddiz/util/MySQLConnectionPool.java
+++ b/src/main/java/de/diddiz/util/MySQLConnectionPool.java
@@ -21,7 +21,7 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
-import java.util.ArrayList;
+import java.util.Vector;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;


### PR DESCRIPTION
Enumerations are no longer concurrently modified, and were replaced with iterators which use the same interface
Vectors replaced with ArrayList for same reason.

This isn't a huge problem, but may fix instability issues which don't throw an exception.