### PR TITLE
Prefixed Chat Log Date

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/ChatMessage.java
+++ b/src/main/java/de/diddiz/LogBlock/ChatMessage.java
@@ -1,5 +1,6 @@
 package de.diddiz.LogBlock;
 
+import de.diddiz.LogBlock.config.Config;
 import static de.diddiz.util.LoggingUtil.checkText;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -34,6 +35,6 @@ public class ChatMessage implements LookupCacheElement
 
 	@Override
 	public String getMessage() {
-		return (player != null ? "<" + player.getName() + "> " : "") + (message != null ? message : "");
+		return Config.formatter.format(date) + " " + (player != null ? "<" + player.getName() + "> " : "") + (message != null ? message : "");
 	}
 }

--- a/src/main/java/de/diddiz/LogBlock/config/Config.java
+++ b/src/main/java/de/diddiz/LogBlock/config/Config.java
@@ -103,7 +103,7 @@ public class Config
 		} catch (IllegalArgumentException e) {
 			throw new DataFormatException("Invalid specification for  date format, please see http://docs.oracle.com/javase/1.4.2/docs/api/java/text/SimpleDateFormat.html : " + e.getMessage());
 		}
-		def.put("lookup.dateFormat", "MM-dd HH:mm:ss");
+		def.put("lookup.dateFormat", "dd/MM/yy HH:mm:ss");
 		def.put("questioner.askRollbacks", true);
 		def.put("questioner.askRedos", true);
 		def.put("questioner.askClearLogs", true);


### PR DESCRIPTION
So, there's pretty much no reason to merge this in but I've modified the previous code a little to add a date prefix in-front of chat logs. Reason for that being the fact that I've been looking at a few chat messages from a few pesky people lately but I can never actually find the date in which it happened accurately. This little patch fixes that and saves my day in particular.

I've also updated the config file for a (pretty much) more universal date string. I didn't like how it was output-ing the date as 'MM-dd' really really ugly.