### PR TITLE
Build automation improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.diddiz</groupId>
@@ -13,7 +13,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<build.number>Unknown</build.number>
+		<build.number>${buildNumber}</build.number>
 	</properties>
 
 	<scm>
@@ -27,16 +27,16 @@
 		<url>http://ci.kitteh.org/job/LogBlock</url>
 	</ciManagement>
 
-        <distributionManagement>
-            <repository>
-                <id>md_5-releases</id>
-                <url>http://repo.md-5.net/content/repositories/releases/</url>
-            </repository>
-            <snapshotRepository>
-                <id>md_5-snapshots</id>
-                <url>http://repo.md-5.net/content/repositories/snapshots/</url>
-            </snapshotRepository>
-        </distributionManagement>
+	<distributionManagement>
+		<repository>
+			<id>md_5-releases</id>
+			<url>http://repo.md-5.net/content/repositories/releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>md_5-snapshots</id>
+			<url>http://repo.md-5.net/content/repositories/snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
 
 	<dependencies>
 		<dependency>
@@ -72,6 +72,32 @@
 			<url>http://repo.kitteh.org/content/groups/public</url>
 		</repository>
 	</repositories>
+	<profiles>
+		<profile>
+			<id>static_build_number</id>
+			<activation>
+				<property>
+					<name>!env.BUILD_NUMBER</name>
+				</property>
+			</activation>
+			<properties>
+				<buildNumber>0</buildNumber>
+				<buildDescription>(manually compiled)</buildDescription>
+			</properties>
+		</profile>
+		<profile>
+			<id>dynamic_build_number</id>
+			<activation>
+				<property>
+					<name>env.BUILD_NUMBER</name>
+				</property>
+			</activation>
+			<properties>
+				<buildNumber>${env.BUILD_NUMBER}</buildNumber>
+				<buildDescription>(build #${env.BUILD_NUMBER})</buildDescription>
+			</properties>
+		</profile>
+	</profiles>
 
 	<build>
 		<finalName>${project.name}</finalName>
@@ -91,6 +117,27 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.9.1</version>
+				<executions>
+					<execution>
+						<id>regex-property</id>
+						<goals>
+							<goal>regex-property</goal>
+						</goals>
+						<configuration>
+							<name>minecraft.plugin.version</name>
+							<value>${project.version} ${buildDescription}</value>
+							<regex>[0-9\.]+ \(.+\)</regex>
+							<replacement>${project.version}</replacement>
+							<failIfNoMatch>false</failIfNoMatch>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ${project.name}
-version: '1.94'
+version: '${minecraft.plugin.version}'
 author: DiddiZ
 authors: [md_5, ammar2, frymaster]
 website: http://dev.bukkit.org/server-mods/logblock/


### PR DESCRIPTION
This has a minor impact but has the potential to confuse the hell out of people if they've not come across it before, so I thought this was better as a PR

This does several interrelated things:

* It alters ``plugin.yml`` to tell maven to insert a version number for the plugin from the build
* It sets the build number from jenkins and creates a build description:
    - If we were built by Jenkins, it uses ``(build #<whatever>)``
    - Otherwise, it uses ``(manually compiled)``
* It sets the property maven will use for the ``plugin.yml`` to a combination of the project version and the build description...
* **but** if the project version consists only of numbers and periods (in other words doesn't have ``-SNAPSHOT`` in the name) sets it to *just* the project version, leaving off the build info

What this looks like if you have "1.94-dev-SNAPSHOT" as the version in ``pom.xml``
``[13:58:17 INFO]: LogBlock version 1.94-dev-SNAPSHOT (build #19)``
(Built from my [personal Jenkins](http://ci.frymaster.127001.org/job/logblock-local-development/), hence the low build numbers)

What this looks like if you have "1.94" as the version in ``pom.xml``
``[13:54:07 INFO]: LogBlock version 1.94``

The net effect is if someone on a dev build does ``/version logblock`` it will tell us the exact build they used, but won't bother showing that stuff for releases. It also means the version numbers in ``pom.xml`` and ``plugin.yml`` are kept in sync and you only have to change it in ``pom.xml``