### PR TITLE
Fix for the toolblock disappearing on use

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/listeners/ToolListener.java
+++ b/src/main/java/de/diddiz/LogBlock/listeners/ToolListener.java
@@ -44,6 +44,7 @@ public class ToolListener implements Listener {
                     if (!isLogged(player.getWorld())) {
                         player.sendMessage(ChatColor.RED + "This world is not currently logged.");
                         event.setCancelled(true);
+                        player.updateInventory();
                         return;
                     }
                     final Block block = event.getClickedBlock();
@@ -83,6 +84,7 @@ public class ToolListener implements Listener {
                         player.sendMessage(ChatColor.RED + ex.getMessage());
                     }
                     event.setCancelled(true);
+                    player.updateInventory();
                 }
             }
         }


### PR DESCRIPTION
When using a toolblock, it typically disappears from the inventory after the PlayerInteractEvent is cancelled, and doesn't return until an inventory update is triggered. By forcing an inventory update, this issue is avoided.

![GIF](http://i.imgur.com/327D8EI.gif)
