### PR TITLE
Update for 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.diddiz</groupId>
     <artifactId>logblock</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.12-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>LogBlock</name>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.11-R0.1-SNAPSHOT</version>
+            <version>1.12-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/diddiz/util/BukkitUtils.java
+++ b/src/main/java/de/diddiz/util/BukkitUtils.java
@@ -95,6 +95,7 @@ public class BukkitUtils {
         relativeTopFallables.add(Material.GRAVEL);
         relativeTopFallables.add(Material.DRAGON_EGG);
         relativeTopFallables.add(Material.ANVIL);
+        relativeTopFallables.add(Material.CONCRETE_POWDER);
 
         // Blocks that break falling entities
         fallingEntityKillers = new HashSet<Material>(32);

--- a/src/main/java/de/diddiz/util/MaterialName.java
+++ b/src/main/java/de/diddiz/util/MaterialName.java
@@ -178,10 +178,12 @@ public class MaterialName {
             for (byte i = 0; i < 16; i++) {
                 cfg.set("351." + i, toReadable(Material.INK_SACK.getNewData(i)));
                 cfg.set("35." + i, COLORS[i] + " wool");
-                cfg.set("159." + i, COLORS[i] + " stained clay");
+                cfg.set("159." + i, COLORS[i] + " stained terracotta");
                 cfg.set("95." + i, COLORS[i] + " stained glass");
                 cfg.set("160." + i, COLORS[i] + " stained glass pane");
                 cfg.set("171." + i, COLORS[i] + " carpet");
+                cfg.set("251." + i, COLORS[i] + " concrete");
+                cfg.set("252." + i, COLORS[i] + " concrete powder");
             }
             for (byte i = 0; i < 6; i++) {
                 cfg.set("125." + i, toReadable(Material.WOOD_DOUBLE_STEP.getNewData(i)));
@@ -194,7 +196,7 @@ public class MaterialName {
                 getLogger().log(Level.WARNING, "Unable to save material.yml: ", ex);
             }
         }
-        if (cfg.getString("263.1") == null) {
+        if (cfg.getString("252.1") == null) {
             getLogger().info("[Logblock-names] Logblock's default materials.yml file has been updated with more names");
             getLogger().info("[Logblock-names] Consider deleting your current materials.yml file to allow it to be recreated");
         }


### PR DESCRIPTION
Update for Minecraft Version 1.12

- switched to Bukkit version 1.12
- added concrete powder to falling blocks
- added names for the colors for concrete and concrete powder
- changed "stained clay" to "stained terracotta"
- changed id trigger for the _Logblock-names_ info message 