### PR TITLE
Change `materials.yml` location to relative

### DIFF
--- a/src/main/java/de/diddiz/util/MaterialName.java
+++ b/src/main/java/de/diddiz/util/MaterialName.java
@@ -1,5 +1,6 @@
 package de.diddiz.util;
 
+import de.diddiz.LogBlock.LogBlock;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -27,7 +28,7 @@ public class MaterialName {
             materialNames.put(mat.getId(), mat.toString().replace('_', ' ').toLowerCase());
         }
         // Load config
-        final File file = new File("plugins/LogBlock/materials.yml");
+        final File file = new File(LogBlock.getInstance().getDataFolder(), "materials.yml");
         final YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
         if (cfg.getKeys(false).isEmpty()) {
             // Generate defaults


### PR DESCRIPTION
Hello,

I have found that by changing the `plugins` directory the `materials.yml` is created in the wrong folder.

Example for reproducing:

```
Plugin logBlock = Bukkit.getServer().getPluginManager().loadPlugin(new File("example/LogBlock.jar"));
logBlock.onLoad();
Bukkit.getServer().getPluginManager().enablePlugin(logBlock);
```

Result (**before fix**):

```
example/
  LogBlock/
    config.yml
    ...
  LogBlock.jar
plugins/
  LogBlock/
    materials.yml
```
Result (**after fix**)
```
example/
  LogBlock/
    config.yml
    materials.yml
    ...
  LogBlock.jar
```