### PR TITLE
Fixed WorldEdit check to handle 3rd party versions that may not have …

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/LogBlock.java
+++ b/src/main/java/de/diddiz/LogBlock/LogBlock.java
@@ -102,10 +102,15 @@ public class LogBlock extends JavaPlugin {
         }
         
         if (pm.getPlugin("WorldEdit") != null) {
-            if (Integer.parseInt(pm.getPlugin("WorldEdit").getDescription().getVersion().substring(0, 1)) > 5) {
+            try {
+                if (Integer.parseInt(pm.getPlugin("WorldEdit").getDescription().getVersion().substring(0, 1)) > 5) {
+                    new WorldEditLoggingHook(this).hook();
+                } else {
+                    getLogger().warning("Failed to hook into WorldEdit. Your WorldEdit version seems to be outdated, please make sure WorldEdit is at least version 6.");
+                }
+            }catch(NumberFormatException ex){
+                getLogger().warning("Failed to Read WorldEdit Version! Your WorldEdit version maybe outdated, please make sure WorldEdit is at least version 6.");
                 new WorldEditLoggingHook(this).hook();
-            } else {
-                getLogger().warning("Failed to hook into WorldEdit. Your WorldEdit version seems to be outdated, please make sure WorldEdit is at least version 6.");
             }
         }
         commandsHandler = new CommandsHandler(this);


### PR DESCRIPTION
…an expected numeric version.

This won't handle weird numeric versions, just the AsyncworldEdit 'unspecified' version like cases. 