### PR TITLE
Add public to the ChestAccess variables

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/ChestAccess.java
+++ b/src/main/java/de/diddiz/LogBlock/ChestAccess.java
@@ -3,9 +3,9 @@ package de.diddiz.LogBlock;
 import org.bukkit.inventory.ItemStack;
 
 public class ChestAccess {
-    final ItemStack itemStack;
-    final boolean remove;
-    final int itemType;
+    public final ItemStack itemStack;
+    public final boolean remove;
+    public final int itemType;
 
     public ChestAccess(ItemStack itemStack, boolean remove, int itemType) {
         this.itemStack = itemStack;


### PR DESCRIPTION
This allows an external plugin to access these 3 variables through the API.