### PR TITLE
Fix beacon logging, they are not a container (fix #762)

### DIFF
--- a/src/main/java/de/diddiz/util/BukkitUtils.java
+++ b/src/main/java/de/diddiz/util/BukkitUtils.java
@@ -306,7 +306,6 @@ public class BukkitUtils {
         containerBlocks.add(Material.HOPPER);
         containerBlocks.add(Material.BREWING_STAND);
         containerBlocks.add(Material.FURNACE);
-        containerBlocks.add(Material.BEACON);
         containerBlocks.add(Material.SHULKER_BOX);
         containerBlocks.add(Material.BLACK_SHULKER_BOX);
         containerBlocks.add(Material.BLUE_SHULKER_BOX);


### PR DESCRIPTION
This fixes issue #762.

`Beacon` is not an instance of `InventoryHolder`, at least on 1.14.4.

```
if (!(container instanceof InventoryHolder)) {
     return;
}
```

This code was therefore preventing beacon breaks from being logged.