### PR TITLE
Update mysql-connector-java to version 8.0.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.19</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.7.25</version>
@@ -166,6 +172,10 @@
                                 <relocation>
                                     <pattern>com.zaxxer.hikari</pattern>
                                     <shadedPattern>de.diddiz.lib.com.zaxxer.hikari</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.mysql</pattern>
+                                    <shadedPattern>de.diddiz.lib.com.mysql</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.slf4j</pattern>

--- a/src/main/java/de/diddiz/LogBlock/LogBlock.java
+++ b/src/main/java/de/diddiz/LogBlock/LogBlock.java
@@ -73,7 +73,7 @@ public class LogBlock extends JavaPlugin {
         }
         try {
             getLogger().info("Connecting to " + user + "@" + url + "...");
-            Class.forName("com.mysql.jdbc.Driver");
+            Class.forName("com.mysql.cj.jdbc.Driver");
             pool = new MySQLConnectionPool(url, user, password, mysqlUseSSL, mysqlRequireSSL);
             final Connection conn = getConnection(true);
             if (conn == null) {


### PR DESCRIPTION
This updates `mysql-connector-java` dependency to version 8.0.19. CraftBukkit uses an old JDBC connector version 5.1.48 which does not support `caching_sha2_password` plugin.

Related: https://mysqlserverteam.com/upgrading-to-mysql-8-0-default-authentication-plugin-considerations/
CraftBukkit's dependency: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/pom.xml?until=544ccdc588a77020088383e167491c1d75d7b7e7&untilPath=pom.xml#62-67