### PR TITLE
update enginehub repository location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         </repository>
         <repository>
             <id>sk89q-repo</id>
-            <url>https://maven.sk89q.com/repo/</url>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
             <id>brokkonaut-repo</id>


### PR DESCRIPTION
from the EngineHub discord:
> The Maven repository for all our projects has been migrated to a new server, for long-term stability.
> 
> Due to this change, the previously deprecated legacy repository URL maven.sk89q.com is NO LONGER UPDATED. Please migrate to using https://maven.enginehub.org/repo/ ASAP, as new releases will ONLY be seen there.
> 
> Additionally, many proxied repos have been removed. Please use the appropriate repository to pull your artifacts.

the build broke and this fixes it (#848)
