### PR TITLE
exclude worldedit dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,24 @@
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.2.7-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
             <version>7.0.6-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
the build was still broken (https://jitpack.io/com/github/logblock/logblock/6d0ac7169c/build.log)

i think jenkins was able to do it successfully because it had those dependencies cached
logblock doesn't use those dependencies, so it doesn't include the repositories which is causing the problem