### PR TITLE
don't exclude dependencies and add jitpack configuration

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open
+
+jdk:
+  - openjdk17

--- a/pom.xml
+++ b/pom.xml
@@ -52,24 +52,12 @@
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.2.7-SNAPSHOT</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
             <version>7.0.6-SNAPSHOT</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
sorry for spamming pull requests, i [actually tested it](https://jitpack.io/com/github/logblock/logblock/PR851-c35a93fa56-1/build.log) this time and it works so hopefully it's the last one related to the build system
excluding the dependencies actually broke the build too, but we don't have to exclude them anymore since they can now be found in the enginehub repo (they were not there before)
also added jitpack configuration so that it can build successfully