### PR TITLE
MariaDB 11 compatibility fix: configurable protocol

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/config/Config.java
+++ b/src/main/java/de/diddiz/LogBlock/config/Config.java
@@ -81,6 +81,7 @@ public class Config {
             worldNames.add("world_the_end");
         }
         def.put("loggedWorlds", worldNames);
+        def.put("mysql.protocol", "mysql");
         def.put("mysql.host", "localhost");
         def.put("mysql.port", 3306);
         def.put("mysql.database", "minecraft");
@@ -179,7 +180,7 @@ public class Config {
         boolean oldConfig = configVersion.compareTo(new ComparableVersion(CURRENT_CONFIG_VERSION)) < 0;
 
         mysqlDatabase = getStringIncludingInts(config, "mysql.database");
-        url = "jdbc:mysql://" + config.getString("mysql.host") + ":" + config.getInt("mysql.port") + "/" + mysqlDatabase;
+        url = "jdbc:" + config.getString("mysql.protocol") + "://" + config.getString("mysql.host") + ":" + config.getInt("mysql.port") + "/" + mysqlDatabase;
         user = getStringIncludingInts(config, "mysql.user");
         password = getStringIncludingInts(config, "mysql.password");
         mysqlUseSSL = config.getBoolean("mysql.useSSL", true);


### PR DESCRIPTION
This MR adds a config option to set the mysql protocol type to mariadb. By default this option is set to mysql to keep the config backwards compatible.

The fix is required because the jdbc driver for mysql is incompatible with mariadb 11. To force the connection with the mariadb connector the protocol has to be specified as mariadb.

The required mariadb-connector is not included in this MR and can be added by the server administrator as third party library or by other plugins.