### PR TITLE
Fix #875

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,13 +68,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.4.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>5.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -173,10 +167,6 @@
                                 <relocation>
                                     <pattern>com.zaxxer.hikari</pattern>
                                     <shadedPattern>de.diddiz.lib.com.zaxxer.hikari</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.slf4j</pattern>
-                                    <shadedPattern>de.diddiz.lib.org.slf4j</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Update HikariCP

Plugin is starting without an issue, so slf4j is realy not needed.