### PR TITLE
.editorconfig fix for end_of_line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
all existing files use `crlf` for `end_of_line` not `lf`