### PR TITLE
Fix duplicate set entry & add missing piglin head

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/util/BukkitUtils.java
+++ b/src/main/java/de/diddiz/LogBlock/util/BukkitUtils.java
@@ -186,8 +186,7 @@ public class BukkitUtils {
 
         Set<Material> bannerAll = Tag.BANNERS.getValues();
 
-        Set<Material> headAndSkulls = Set.of(Material.SKELETON_WALL_SKULL,
-            Material.PLAYER_HEAD,
+        Set<Material> headAndSkulls = Set.of(Material.PLAYER_HEAD,
             Material.PLAYER_WALL_HEAD,
             Material.CREEPER_HEAD,
             Material.CREEPER_WALL_HEAD,
@@ -198,7 +197,9 @@ public class BukkitUtils {
             Material.SKELETON_SKULL,
             Material.SKELETON_WALL_SKULL,
             Material.WITHER_SKELETON_SKULL,
-            Material.WITHER_SKELETON_WALL_SKULL);
+            Material.WITHER_SKELETON_WALL_SKULL,
+            Material.PIGLIN_HEAD,
+            Material.PIGLIN_WALL_HEAD);
 
         Set<Material> standingTorch = Set.of(Material.TORCH,
             Material.SOUL_TORCH,


### PR DESCRIPTION
The plugin won't start due to a duplicate set entry. This removes the duplicate Material.SKELETON_WALL_SKULL and also adds the missing Piglin head materials.

Fixes #889 