### PR TITLE
Fix BukkitUtils#entityName for NPCs and custom Entities

### DIFF
--- a/src/main/java/de/diddiz/LogBlock/util/BukkitUtils.java
+++ b/src/main/java/de/diddiz/LogBlock/util/BukkitUtils.java
@@ -564,7 +564,12 @@ public class BukkitUtils {
         if (entity instanceof TNTPrimed) {
             return "TNT";
         }
-        return entity.getClass().getSimpleName().substring(5);
+
+        String simpleClassName = entity.getClass().getSimpleName();
+        if(simpleClassName.startsWith("Craft"))
+            return simpleClassName.substring(5);
+
+        return simpleClassName;
     }
 
     public static void giveTool(Player player, Material type) {


### PR DESCRIPTION
Fix BukkitUtils#entityName for NPCs and custom Entities, fixes:

```
com.destroystokyo.paper.exception.ServerEventException: Could not pass event EntityChangeBlockEvent to LogBlock v1.20.0.0-SNAPSHOT (build #222)
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:72)
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131)
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628)
	at org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(CraftEventFactory.java:1238)
	at org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(CraftEventFactory.java:1230)
	at net.minecraft.world.level.block.BigDripleafBlock.setTilt(BigDripleafBlock.java:273)
	at net.minecraft.world.level.block.BigDripleafBlock.setTiltAndScheduleTick(BigDripleafBlock.java:249)
	at net.minecraft.world.level.block.BigDripleafBlock.entityInside(BigDripleafBlock.java:210)
	at net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.entityInside(BlockBehaviour.java:895)
	at net.minecraft.world.entity.Entity.lambda$checkInsideBlocks$2(Entity.java:2005)
	at net.minecraft.world.level.BlockGetter.forEachBlockIntersectedBetween(BlockGetter.java:225)
	at net.minecraft.world.entity.Entity.checkInsideBlocks(Entity.java:1970)
	at net.minecraft.world.entity.Entity.checkInsideBlocks(Entity.java:1949)
	at net.minecraft.world.entity.Entity.applyEffectsFromBlocks(Entity.java:1479)
	at net.minecraft.world.entity.Entity.applyEffectsFromBlocks(Entity.java:1440)
	at net.minecraft.world.entity.LivingEntity.aiStep(LivingEntity.java:3633)
	at net.minecraft.world.entity.Mob.aiStep(Mob.java:504)
	at net.minecraft.world.entity.LivingEntity.tick(LivingEntity.java:3353)
	at net.minecraft.world.entity.Mob.tick(Mob.java:381)
	at SimplePets.jar//simplepets.brainsynder.versions.v1_21_7.entity.EntityPet.tick(EntityPet.java:453)
	at net.minecraft.server.level.ServerLevel.tickNonPassenger(ServerLevel.java:1306)
	at net.minecraft.world.level.Level.guardEntityTick(Level.java:1511)
	at net.minecraft.server.level.ServerLevel.lambda$tick$5(ServerLevel.java:840)
	at net.minecraft.world.level.entity.EntityTickList.forEach(EntityTickList.java:39)
	at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:813)
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1741)
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1548)
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1269)
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:311)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.StringIndexOutOfBoundsException: Range [5, 0) out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
	at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4865)
	at java.base/java.lang.String.substring(String.java:2834)
	at java.base/java.lang.String.substring(String.java:2807)
	at LogBlock.jar//de.diddiz.LogBlock.util.BukkitUtils.entityName(BukkitUtils.java:567)
	at LogBlock.jar//de.diddiz.LogBlock.Actor.actorFromEntity(Actor.java:122)
	at LogBlock.jar//de.diddiz.LogBlock.listeners.EntityChangeBlockLogging.onEntityChangeBlock(EntityChangeBlockLogging.java:42)
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80)
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71)
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54)
	... 29 more
```
(and similar)

Not sure if there's not a better way to go about this tho...